### PR TITLE
added react-native as peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
   ],
   "author": "Thiago Porto",
   "license": "MIT",
-  "dependencies": {
-    "react": ">=15.4.1",
+  "peerDependencies": {
     "react-native": ">=0.38.0"
+  },
+  "dependencies": {
+    "react": ">=15.4.1"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",


### PR DESCRIPTION
Expo start gives error of having duplicate Animate library, which is result of two react-native libraries one in the main package and other in the project. This is an attempt to resolve it.